### PR TITLE
wire up to backend services

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -3,4 +3,12 @@
           :allowed-origins #resource-config/edn #resource-config/env "ALLOWED_ORIGINS"}
  :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
-            :queues {"election-mail-http-api.ok" {:exclusive false :durable true :auto-delete false}}}}
+            :queues {"election-mail-http-api.ok" {:exclusive false :durable true :auto-delete false}
+                     "election-mail-http-api.mailing.forms" {:exclusive false :durable true :auto-delete false}
+                     "election-mail-http-api.subscription.read" {:exclusive false :durable true :auto-delete false}
+                     "election-mail-http-api.subscription.create" {:exclusive false :durable true :auto-delete false}
+                     "election-mail-http-api.subscription.delete" {:exclusive false :durable true :auto-delete false}}}
+ :timeouts {:mailing-forms 20000
+            :subscription-read 10000
+            :subscription-create 10000
+            :subscription-delete 10000}}

--- a/src/election_mail_http_api/channels.clj
+++ b/src/election_mail_http_api/channels.clj
@@ -5,6 +5,16 @@
 (defonce ok-requests (async/chan))
 (defonce ok-responses (async/chan))
 
+(defonce mailing-forms (async/chan))
+
+(defonce subscription-read (async/chan))
+(defonce subscription-create (async/chan))
+(defonce subscription-delete (async/chan))
+
 (defn close-all! []
-  (doseq [c [ok-requests ok-responses]]
+  (doseq [c [ok-requests ok-responses
+             mailing-forms
+             subscription-read
+             subscription-create
+             subscription-delete]]
     (async/close! c)))

--- a/src/election_mail_http_api/queue.clj
+++ b/src/election_mail_http_api/queue.clj
@@ -19,12 +19,43 @@
                               (config [:rabbitmq :queues "election-mail-http-api.ok"])
                               channels/ok-requests
                               channels/ok-responses)]
-          external-services []
+          external-services [(wire-up/external-service
+                              connection
+                              ""
+                              "election-mail-http-api.mailing.forms"
+                              (config [:rabbitmq :queues "election-mail-http-api.mailing.forms"])
+                              (config [:timeouts :mailing-forms])
+                              channels/mailing-forms)
+
+                             (wire-up/external-service
+                              connection
+                              ""
+                              "election-mail-http-api.subscription.read"
+                              (config [:rabbitmq :queues "election-mail-http-api.subscription.read"])
+                              (config [:timeouts :subscription-read])
+                              channels/subscription-read)
+
+                             (wire-up/external-service
+                              connection
+                              ""
+                              "election-mail-http-api.subscription.create"
+                              (config [:rabbitmq :queues "election-mail-http-api.subscription.create"])
+                              (config [:timeouts :subscription-create])
+                              channels/subscription-create)
+
+                             (wire-up/external-service
+                              connection
+                              ""
+                              "election-mail-http-api.subscription.delete"
+                              (config [:rabbitmq :queues "election-mail-http-api.subscription.delete"])
+                              (config [:timeouts :subscription-delete])
+                              channels/subscription-delete)]
           outgoing-events []]
 
       (wire-up/start-responder! channels/ok-requests
                                 channels/ok-responses
                                 handlers/ok)
+
       
       {:connections [connection]
        :channels (vec (concat

--- a/src/election_mail_http_api/service.clj
+++ b/src/election_mail_http_api/service.clj
@@ -27,7 +27,26 @@
                                                        "application/transit+msgpack"
                                                        "application/json"
                                                        "text/plain"])]
-     ["/ping" {:get [:ping ping]}]]]])
+     ["/ping" {:get [:ping ping]}]
+     ["/subscriptions/:user-id"
+      ^:interceptors [(bifrost.i/update-in-request
+                       [:path-params :user-id]
+                       #(java.util.UUID/fromString %))
+                      (bifrost.i/update-in-response
+                       [:body :subscription]
+                       [:body] identity)]
+      {:get [:subscription-read
+             (bifrost/interceptor
+              channels/subscription-read)]
+       :put [:subscription-create
+             (bifrost/interceptor
+              channels/subscription-create)]
+       :delete [:subscription-delete
+                (bifrost/interceptor
+                 channels/subscription-delete)]}]
+     ["/mailing-forms" {:put [:mailing-forms
+                              (bifrost/interceptor
+                               channels/mailing-forms)]}]]]])
 
 (defn service []
   {::env :prod

--- a/test/election_mail_http_api/service_test.clj
+++ b/test/election_mail_http_api/service_test.clj
@@ -1,18 +1,24 @@
 (ns election-mail-http-api.service-test
   (:require [election-mail-http-api.server :as server]
+            [election-mail-http-api.channels :as channels]
             [clj-http.client :as http]
             [clojure.edn :as edn]
             [cognitect.transit :as transit]
             [clojure.core.async :as async]
-            [clojure.test :refer :all]))
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [bifrost.core :as bifrost])
+  (:import [java.io ByteArrayInputStream]))
 
-(def test-server-port 56000) ; FIXME: Pick a port unique to this project
+(def test-server-port 65342) ; FIXME: Pick a port unique to this project
 
-(defn start-test-server [run-tests]
-  (server/start-http-server {:io.pedestal.http/port test-server-port})
-  (run-tests))
+(defn run-test-server [run-tests]
+  (let [service-map
+        (server/start-http-server {:io.pedestal.http/port test-server-port})]
+    (run-tests)
+    (io.pedestal.http/stop service-map)))
 
-(use-fixtures :once start-test-server)
+(use-fixtures :each run-test-server)
 
 (def root-url (str "http://localhost:" test-server-port))
 
@@ -22,3 +28,177 @@
                              {:headers {:accept "text/plain"}})]
       (is (= 200 (:status response)))
       (is (= "OK" (:body response))))))
+
+(deftest create-subscription-test
+  (testing "PUT to /subscriptions/:user-id puts appropriate create message
+            on subscription-create channel"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/put (str/join "/"
+                                                 [root-url
+                                                  "subscriptions"
+                                                  fake-user-id])
+                                       {:headers {:accept "application/edn"}
+                                        :form-params {:subscribe true}
+                                        :content-type :edn}))
+          [response-ch message] (async/alt!!
+                                  channels/subscription-create ([v] v)
+                                  (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (is (= {:user-id fake-user-id
+              :subscribe true}
+             message))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :subscribed true}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :subscribed true}
+               (-> http-response :body edn/read-string))))))
+  (testing "PUT to /subscriptions/:user-id can respond with Transit"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/put
+                              (str/join "/" [root-url
+                                             "subscriptions"
+                                             fake-user-id])
+                              {:headers {:accept "application/transit+json"}
+                               :form-params {:subscribe true}
+                               :content-type :edn}))
+          [response-ch message] (async/alt!! channels/subscription-create ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                              :subscribed true}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            transit-in (ByteArrayInputStream. (-> http-response
+                                                  :body
+                                                  (.getBytes "UTF-8")))
+            transit-reader (transit/reader transit-in :json)
+            create-data (transit/read transit-reader)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (:subscribe message))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :subscribed true} create-data)))))
+  (testing "error from backend service results in HTTP server error response"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/put (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id])
+                                       {:headers {:accept "application/edn"}
+                                        :form-params {:subscribe true}
+                                        :content-type :edn
+                                        :throw-exceptions false}))
+          [response-ch message] (async/alt!! channels/subscription-create ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :error
+                              :error {:type :server}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 500 (:status http-response))))))
+  (testing "no response from backend service results in HTTP gateway timeout error response"
+    (with-redefs [bifrost/*response-timeout* 500]
+      (let [fake-user-id (java.util.UUID/randomUUID)
+            http-response-ch (async/thread
+                               (http/put (str/join "/" [root-url
+                                                        "subscriptions"
+                                                        fake-user-id])
+                                         {:headers {:accept "application/edn"}
+                                          :form-params {:subscribe true}
+                                          :content-type :edn
+                                          :throw-exceptions false}))
+            [response-ch message] (async/alt!! channels/subscription-create ([v] v)
+                                               (async/timeout 1000) [nil ::timeout])]
+        (assert (not= message ::timeout))
+        (let [http-response (async/alt!! http-response-ch ([v] v)
+                                         (async/timeout 1000) ::timeout)]
+          (assert (not= http-response ::timeout))
+          (is (= 504 (:status http-response))))))))
+
+(deftest delete-subscription-test
+  (testing "DELETE to /subscriptions/:user-id puts appropriate create message
+            on subscription-delete channel"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/delete (str/join "/"
+                                                    [root-url
+                                                     "subscriptions"
+                                                     fake-user-id])
+                                          {:headers {:accept "application/edn"}}))
+          [response-ch message] (async/alt!!
+                                  channels/subscription-delete ([v] v)
+                                  (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (is (= {:user-id fake-user-id}
+             message))
+      (async/>!! response-ch {:status :ok})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 200 (:status http-response)))))))
+
+(deftest read-subscription-test
+  (testing "GET to /subscriptions/:user-id puts appropriate read message
+            on subscription-read channel"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/get (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id])
+                                       {:headers {:accept "application/edn"}}))
+          [response-ch message] (async/alt!! channels/subscription-read ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :subscribed true}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :subscribed true}
+               (-> http-response :body edn/read-string)))))))
+
+(deftest test-mailing-forms
+  (testing "PUT to /mailing-forms puts the appropriate message on the
+            mailing-forms channel"
+    (let [forms-data
+          {:user {:first-name "Fake"
+                  :last-name "User"
+                  :addresses {:registered {:street "1507 Blake St"
+                                           :city "Denver"
+                                           :state "CO"
+                                           :zip "80202"}}}
+           :registration-form-uri "http://fake.url.com"
+           :registration-authority {:office-name "Election Office"
+                                    :physical-address
+                                    {:street "1500 Larimer St"
+                                     :city "Denver"
+                                     :state "CO"
+                                     :zip "80202"}}
+           :id-instructions "Fill in your ID number"}
+          http-response-ch (async/thread
+                             (http/put (str/join "/" [root-url
+                                                      "mailing-forms"])
+                                       {:headers {:accept "application/edn"}
+                                        :form-params forms-data
+                                        :content-type :edn}))
+          [response-ch message] (async/alt!!
+                                  channels/mailing-forms ([v] v)
+                                  (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= forms-data message))
+        (is (= 200 (:status http-response)))))))


### PR DESCRIPTION
This isn't exactly covered in a Pivotal Card request anywhere, but will be needed in order for `turbovote-web` to communicate with `election-mail-works`.

Assigning to @danielglauser 